### PR TITLE
Add readme command

### DIFF
--- a/readme.json
+++ b/readme.json
@@ -6,7 +6,7 @@
         "content": "Here's a quick rundown of the roles on this server!",
         "embed": {
             "title": "**Roles**",
-            "description": "```CSS\n- Game Master\n```The admins here, who help run and moderate the server!\n\n```md\n # Bot Developer / Past Bot Developer\n```(some of) The people who created and run the bots! Please don't spam their pings if something goes wrong with the bot, ping the Game Masters instead.\n\n```diff\n- Participant\n```People who are currently playing a game",
+            "text": "```CSS\n- Game Master\n```The admins here, who help run and moderate the server!\n\n```md\n# Bot Developer / Past Bot Developer\n```(some of) The people who created and run the bots! Please don't spam their pings if something goes wrong with the bot, ping the Game Masters instead.\n\n```diff\n- Participant\n```People who are currently playing a game",
             "color": 65280
         }
     },
@@ -14,7 +14,7 @@
     "part3": {
         "embed": {
             "title": "**Discriminatory Content**",
-            "description": "Discriminatory content is not and never will be condoned on the server. This means ALL racist imagery or remarks posted by anyone on the server is sufficient grounds for punishment by a moderator. This is not up for debate - offensive content is not allowed on this server in any form. If you are upset or offended by racist or derogatory content posted on this server, DM a moderator immediately. If you are unsure if your content 'counts' as offensive, do not post it, and DM a moderator if you want clarification.",
+            "text": "Discriminatory content is not and never will be condoned on the server. This means ALL racist imagery or remarks posted by anyone on the server is sufficient grounds for punishment by a moderator. This is not up for debate - offensive content is not allowed on this server in any form. If you are upset or offended by racist or derogatory content posted on this server, DM a moderator immediately. If you are unsure if your content 'counts' as offensive, do not post it, and DM a moderator if you want clarification.",
             "color": 16744192
         }
     },
@@ -23,7 +23,7 @@
         "content": "We would like to make it clear that all these rules are intended to make this server a friendly and welcoming place for everybody. We're all here to try and have some fun! Keep that in mind when considering your actions. :smiley:",
         "embed": {
             "title": "**Rules**",
-            "description": "```diff\n- No offensive messages or nicknames\n+ Anything that a reasonable person may find offensive.\n- No spam\n+ This includes, but is not limited to, @mention spam, message or image spam, or loud/obnoxious noises in voice channels.\n- No inappropriate content\n- No harassment\n+ Including sexual harassment or encouraging or harassment.\n- Use the appropriate channels\n\nIf you aim something at another member intended as a joke and they do not take it as so, just apologise and move on.\nDo not discuss any illegal activity on the server - remember that people's lives and careers have been impacted by messing with the wrong people or activities when they were young.\n\nThere may be situations not covered by the rules or times where the rule may not fit the situation. If this happens, the moderators are trusted to handle the situation appropriately, and reserve the right to take action as they see fit. If you have a complaint about a staff member, you can DM a complaint to another member of staff.\n```",
+            "text": "```diff\n- No offensive messages or nicknames\n+ Anything that a reasonable person may find offensive.\n- No spam\n+ This includes, but is not limited to, @mention spam, message or image spam, or loud/obnoxious noises in voice channels.\n- No inappropriate content\n- No harassment\n+ Including sexual harassment or encouraging or harassment.\n- Use the appropriate channels\n\nIf you aim something at another member intended as a joke and they do not take it as so, just apologise and move on.\nDo not discuss any illegal activity on the server - remember that people's lives and careers have been impacted by messing with the wrong people or activities when they were young.\n\nThere may be situations not covered by the rules or times where the rule may not fit the situation. If this happens, the moderators are trusted to handle the situation appropriately, and reserve the right to take action as they see fit. If you have a complaint about a staff member, you can DM a complaint to another member of staff.\n```",
             "color": 16711680
         }
     }

--- a/readme.json
+++ b/readme.json
@@ -1,0 +1,30 @@
+{
+    "part1": {"content": "**Welcome to the Werewolves Discord Server!** This is a place to play our spinoff version of an old party game called Werewolves. Find out how to play below!"
+    },
+
+    "part2": {
+        "content": "Here's a quick rundown of the roles on this server!",
+        "embed": {
+            "title": "**Roles**",
+            "description": "```CSS\n- Game Master\n```The admins here, who help run and moderate the server!\n\n```md\n # Bot Developer / Past Bot Developer\n```(some of) The people who created and run the bots! Please don't spam their pings if something goes wrong with the bot, ping the Game Masters instead.\n\n```diff\n- Participant\n```People who are currently playing a game",
+            "color": 65280
+        }
+    },
+
+    "part3": {
+        "embed": {
+            "title": "**Discriminatory Content**",
+            "description": "Discriminatory content is not and never will be condoned on the server. This means ALL racist imagery or remarks posted by anyone on the server is sufficient grounds for punishment by a moderator. This is not up for debate - offensive content is not allowed on this server in any form. If you are upset or offended by racist or derogatory content posted on this server, DM a moderator immediately. If you are unsure if your content 'counts' as offensive, do not post it, and DM a moderator if you want clarification.",
+            "color": 16744192
+        }
+    },
+
+    "part4": {
+        "content": "We would like to make it clear that all these rules are intended to make this server a friendly and welcoming place for everybody. We're all here to try and have some fun! Keep that in mind when considering your actions. :smiley:",
+        "embed": {
+            "title": "**Rules**",
+            "description": "```diff\n- No offensive messages or nicknames\n+ Anything that a reasonable person may find offensive.\n- No spam\n+ This includes, but is not limited to, @mention spam, message or image spam, or loud/obnoxious noises in voice channels.\n- No inappropriate content\n- No harassment\n+ Including sexual harassment or encouraging or harassment.\n- Use the appropriate channels\n\nIf you aim something at another member intended as a joke and they do not take it as so, just apologise and move on.\nDo not discuss any illegal activity on the server - remember that people's lives and careers have been impacted by messing with the wrong people or activities when they were young.\n\nThere may be situations not covered by the rules or times where the rule may not fit the situation. If this happens, the moderators are trusted to handle the situation appropriately, and reserve the right to take action as they see fit. If you have a complaint about a staff member, you can DM a complaint to another member of staff.\n```",
+            "color": 16711680
+        }
+    }
+}

--- a/wwbot/__main__.py
+++ b/wwbot/__main__.py
@@ -30,6 +30,7 @@ extensions = (
     "roles",
     "secret_channels",
     "cleanup",
+    "readme_cmds",
 )
 
 @bot.command()

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -1,5 +1,5 @@
 from time import sleep
-from io import StringIO
+from io import BytesIO
 from json import load
 
 import discord
@@ -34,15 +34,10 @@ class ReadmeCommands(commands.Cog, name="Readme"):
 
         # The user has uploaded a config.
         if ctx.message.attachments != []:
-            json_file_location = [_.url for _ in ctx.message.attachments][0]
+            message_attachment = ctx.message.attachments[0]
 
-            # GETs the attachment data.
-            async with ClientSession() as session:
-                async with session.get(json_file_location) as response:
-                    if response.status == 200:
-                        resp_text = await response.text()
+            json_config = load(BytesIO(message_attachment.save()))
 
-            json_config = load(StringIO(resp_text))
             await ctx.send(embed=usr_confirmation)
 
         # No config uploaded, just use default config file.

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -1,7 +1,8 @@
 import discord
-from discord.ext import commands, has_role, command
+from discord.ext import commands, command
 
 from wwbot.config import conf
+from wwbot.permissions import chk_gamemaster
     
     
 class ReadmeCommands(commands.cog, name="Readme"):
@@ -9,7 +10,7 @@ class ReadmeCommands(commands.cog, name="Readme"):
         self.bot = bot
 
     @command()
-    @has_role(conf["ids"]["gamemaster"])
+    @chk_gamemaster()
     async def readme(self, ctx: Context, operand: str = "", channel_id: int = 0, msg_send_interval: int = 0):
         """
         Allows generating, sending and manipulation of JSON file containing the info needed

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -29,7 +29,6 @@ class ReadmeCommands(commands.Cog, name="Readme"):
         # Let's create a series of #readme-capable embeds. If something is uploaded,
         # It will attempt to use that file for the readme, if omitted, it will use
         # the default JSONifed readme file and send that into the channel instead.
-        usr_confirmation = ":white_check_mark: Creating README using uploaded config file"
 
         # The user has uploaded a config.
         if ctx.message.attachments != []:
@@ -37,15 +36,14 @@ class ReadmeCommands(commands.Cog, name="Readme"):
 
             json_config = load(BytesIO(message_attachment.save()))
 
-            await ctx.send(embed=usr_confirmation)
+            await ctx.send(":white_check_mark: Creating README using uploaded config file")
 
         # No config uploaded, just use default config file.
         else:
             with open("readme.json", "rb") as default_json:
                 json_config = load(default_json)
 
-            usr_confirmation = ":ballot_box_with_check: Creating README using default config file."
-            await ctx.send(usr_confirmation)
+            await ctx.send(":ballot_box_with_check: Creating README using default config file.")
 
         for section in json_config:
             # Initialise our message and embed variables each loop.

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -3,7 +3,6 @@ from io import StringIO
 from json import load
 
 import discord
-from discord import Colour, Embed, File, Message
 from discord.ext import commands
 from aiohttp import ClientSession
 
@@ -44,7 +43,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
                         resp_text = await response.text()
 
             json_config = load(StringIO(resp_text))
-            await ctx.send(embed=usr_confirmation_embed)
+            await ctx.send(embed=usr_confirmation)
 
         # No config uploaded, just use default config file.
         else:
@@ -65,12 +64,12 @@ class ReadmeCommands(commands.Cog, name="Readme"):
 
             # We have an embed. Call in the Seahawks.
             if "embed" in json_config[section]:
-                current_embed = Embed()
+                current_embed = discord.Embed()
                 msg_embed = json_config[section]["embed"]
                 if "text" in msg_embed:
                     current_embed.description = msg_embed["text"]
                 if "color" in msg_embed:
-                    current_embed.colour = Colour(int(msg_embed["color"], 16))
+                    current_embed.colour = discord.Colour(int(msg_embed["color"], 16))
 
                 # Parse the fields, if there are any.
                 if "fields" in msg_embed:
@@ -105,7 +104,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
             requesting_user = await self.bot.get_user_info(ctx.message.author.id)
             await requesting_user.send(
                 content="Hey, here's your readme config file!",
-                file=File(raw_json, 'readme.json')
+                file=discord.File(raw_json, 'readme.json')
             )
             await ctx.send(":airplane: **Flying in, check your DMs!**")
 

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -118,7 +118,7 @@ class ReadmeCommands(commands.cog, name="Readme"):
                         if (0 < msg_send_interval < 901):
                             await sleep(msg_send_interval)
 
-                except(Exception):
+                except:
                     parse_fail_embed = Embed(
                         colour=0x673ab7,
                         description=":x: **Error parsing JSON file, please ensure its valid!**"

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -23,11 +23,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
         to create and send the embeds for the #readme channel. Only Game Masters have
         the permissions need to use this command.
         """
-        incorrect_operand_embed = Embed(
-            colour=0x673ab7,
-            description=":shrug: **No subcommand specified.**"
-        )
-        await ctx.send(embed=incorrect_operand_embed)
+        await ctx.send("⚠️ You didn't specify a subcommand!")
 
         
     @readme.command()
@@ -35,10 +31,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
         # Let's create a series of #readme-capable embeds. If something is uploaded,
         # It will attempt to use that file for the readme, if omitted, it will use
         # the default JSONifed readme file and send that into the channel instead.
-        usr_confirmation_embed = Embed(
-            colour=0x4caf50,
-            description=":white_check_mark: **Creating readme using uploaded config file.**"
-        )
+        usr_confirmation = ":white_check_mark: Creating README using uploaded config file"
 
         # The user has uploaded a config.
         if ctx.message.attachments != []:
@@ -58,9 +51,8 @@ class ReadmeCommands(commands.Cog, name="Readme"):
             with open("readme.json", "rb") as default_json:
                 json_config = load(default_json)
 
-            usr_confirmation_embed.description = (":ballot_box_with_check: "
-                                                    "**Creating readme using default config file.**")
-            await ctx.send(embed=usr_confirmation_embed)
+            usr_confirmation = ":ballot_box_with_check: Creating README using default config file."
+            await ctx.send(usr_confirmation)
 
         for section in json_config:
             # Initialise our message and embed variables each loop.

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -1,150 +1,127 @@
+from time import sleep
+from io import StringIO
+from json import load
+
 import discord
-from discord.ext import commands, command
+from discord import Colour, Embed, File, Message
+from discord.ext import commands
+from aiohttp import ClientSession
 
 from wwbot.config import conf
 from wwbot.permissions import chk_gamemaster
     
     
-class ReadmeCommands(commands.cog, name="Readme"):
+class ReadmeCommands(commands.Cog, name="Readme"):
     def __init__(self, bot):
         self.bot = bot
 
-    @command()
     @chk_gamemaster()
-    async def readme(self, ctx: Context, operand: str = "", channel_id: int = 0, msg_send_interval: int = 0):
+    @commands.group(invoke_without_command=True)
+    async def readme(self, ctx: commands.Context):
         """
         Allows generating, sending and manipulation of JSON file containing the info needed
         to create and send the embeds for the #readme channel. Only Game Masters have
         the permissions need to use this command.
         """
+        incorrect_operand_embed = Embed(
+            colour=0x673ab7,
+            description=":shrug: **No subcommand specified.**"
+        )
+        await ctx.send(embed=incorrect_operand_embed)
 
-        README_SEND_ALIASES = ["create", "push", "generate", "send", "make", "build", "upload"]
-        README_RECV_ALIASES = ["fetch", "get", "pull", "download", "retrieve", "dm", "dl"]
+        
+    @readme.command()
+    async def push(self, ctx, channel_id: int = 0, msg_send_interval: int = 0):
+        # Let's create a series of #readme-capable embeds. If something is uploaded,
+        # It will attempt to use that file for the readme, if omitted, it will use
+        # the default JSONifed readme file and send that into the channel instead.
+        usr_confirmation_embed = Embed(
+            colour=0x4caf50,
+            description=":white_check_mark: **Creating readme using uploaded config file.**"
+        )
 
-        operand = operand.lower()
+        # The user has uploaded a config.
+        if ctx.message.attachments != []:
+            json_file_location = [_.url for _ in ctx.message.attachments][0]
 
-        # The supplied operand is incorrect.
-        if not (operand in README_SEND_ALIASES + README_RECV_ALIASES):
-            incorrect_operand_embed = Embed(
-                colour=0x673ab7,
-                description=":shrug: **Invalid readme operand supplied.**"
-            )
-            await ctx.message.delete()
-            await ctx.send(embed=incorrect_operand_embed)
+            # GETs the attachment data.
+            async with ClientSession() as session:
+                async with session.get(json_file_location) as response:
+                    if response.status == 200:
+                        resp_text = await response.text()
 
-        # User missed out the channel_id for certain commands.
-        elif (channel_id == 0 and operand in README_SEND_ALIASES):
-            misssing_channel_embed = Embed(
-                colour=0xff5722,
-                description=":facepalm: **Whoops, you missed out the channel ID! Try again.**"
-            )
-            await ctx.message.delete()
-            await ctx.send(embed=misssing_channel_embed)
+            json_config = load(StringIO(resp_text))
+            await ctx.send(embed=usr_confirmation_embed)
 
-        # Process the request.
+        # No config uploaded, just use default config file.
         else:
-            # Let's create a series of #readme-capable embeds. If something is uploaded,
-            # It will attempt to use that file for the readme, if omitted, it will use
-            # the default JSONifed readme file and send that into the channel instead.
-            if operand in README_SEND_ALIASES:
-                try:
-                    usr_confirmation_embed = Embed(
-                        colour=0x4caf50,
-                        description=":white_check_mark: **Creating readme using uploaded config file.**"
-                    )
+            with open("readme.json", "rb") as default_json:
+                json_config = load(default_json)
 
-                    # The user has uploaded a config.
-                    if ctx.message.attachments != []:
-                        json_file_location = [_.url for _ in ctx.message.attachments][0]
+            usr_confirmation_embed.description = (":ballot_box_with_check: "
+                                                    "**Creating readme using default config file.**")
+            await ctx.send(embed=usr_confirmation_embed)
 
-                        # GETs the attachment data.
-                        async with ClientSession() as session:
-                            async with session.get(json_file_location) as response:
-                                if response.status == 200:
-                                    resp_text = await response.text()
+        for section in json_config:
+            # Initialise our message and embed variables each loop.
+            # This is to prevent leftover data from being re-sent.
+            msg_content, current_embed = None, None
 
-                        json_config = load(StringIO(resp_text))
-                        await ctx.send(embed=usr_confirmation_embed)
+            # The part which handles general messages.
+            if "content" in json_config[section]:
+                msg_content = json_config[section]["content"]
 
-                    # No config uploaded, just use default config file.
-                    else:
-                        with open("readme.json", "rb") as default_json:
-                            json_config = load(default_json)
+            # We have an embed. Call in the Seahawks.
+            if "embed" in json_config[section]:
+                current_embed = Embed()
+                msg_embed = json_config[section]["embed"]
+                if "text" in msg_embed:
+                    current_embed.description = msg_embed["text"]
+                if "color" in msg_embed:
+                    current_embed.colour = Colour(int(msg_embed["color"], 16))
 
-                        usr_confirmation_embed.description = (":ballot_box_with_check: "
-                                                              "**Creating readme using default config file.**")
-                        await ctx.send(embed=usr_confirmation_embed)
+                # Parse the fields, if there are any.
+                if "fields" in msg_embed:
+                    for current_field in msg_embed["fields"]:
+                        # Add the fields to the current embed.
+                        current_embed.add_field(
+                            name=current_field["name"],
+                            value=current_field["value"]
+                        )
 
-                    await ctx.message.delete()
+            # Send the message.
+            requested_channel = self.bot.get_channel(channel_id)
 
-                    for section in json_config:
-                        # Initialise our message and embed variables each loop.
-                        # This is to prevent leftover data from being re-sent.
-                        msg_content, current_embed = None, None
+            if (msg_content is not None and current_embed is None):
+                await requested_channel.send(content=msg_content)
+            elif (current_embed is not None and msg_content is None):
+                await requested_channel.send(embed=current_embed)
+            else:
+                await requested_channel.send(content=msg_content, embed=current_embed)
 
-                        # The part which handles general messages.
-                        if "content" in json_config[section]:
-                            msg_content = json_config[section]["content"]
+            # User has requested a delay between each message being sent.
+            if (0 < msg_send_interval < 901):
+                await sleep(msg_send_interval)
 
-                        # We have an embed. Call in the Seahawks.
-                        if "embed" in json_config[section]:
-                            current_embed = Embed()
-                            msg_embed = json_config[section]["embed"]
-                            if "text" in msg_embed:
-                                current_embed.description = msg_embed["text"]
-                            if "color" in msg_embed:
-                                current_embed.colour = Colour(int(msg_embed["color"], 16))
+    @readme.command()
+    async def pull(self, ctx):
+        # Get the human-readble readme data.
+        with open("readme.json", "rb") as readme_json:
+            raw_json = readme_json.read()
 
-                            # Parse the fields, if there are any.
-                            if "fields" in msg_embed:
-                                for current_field in msg_embed["fields"]:
-                                    # Add the fields to the current embed.
-                                    current_embed.add_field(
-                                        name=current_field["name"],
-                                        value=current_field["value"]
-                                    )
+            # Slide it to the user's DMs.
+            requesting_user = await self.bot.get_user_info(ctx.message.author.id)
+            await requesting_user.send(
+                content="Hey, here's your readme config file!",
+                file=File(raw_json, 'readme.json')
+            )
 
-                        # Send the message.
-                        requested_channel = self.bot.get_channel(channel_id)
-
-                        if (msg_content is not None and current_embed is None):
-                            await requested_channel.send(content=msg_content)
-                        elif (current_embed is not None and msg_content is None):
-                            await requested_channel.send(embed=current_embed)
-                        else:
-                            await requested_channel.send(content=msg_content, embed=current_embed)
-
-                        # User has requested a delay between each message being sent.
-                        if (0 < msg_send_interval < 901):
-                            await sleep(msg_send_interval)
-
-                except:
-                    parse_fail_embed = Embed(
-                        colour=0x673ab7,
-                        description=":x: **Error parsing JSON file, please ensure its valid!**"
-                    )
-                    await ctx.message.delete()
-                    await ctx.send(embed=parse_fail_embed)
-
-            # Pull the readme JSON constant files and slide it into the user's DMs.
-            elif operand in README_RECV_ALIASES:
-                # Get the human-readble readme data.
-                with open("readme.json", "rb") as readme_json:
-                    raw_json = readme_json.read()
-
-                    # Slide it to the user's DMs.
-                    requesting_user = await self.bot.get_user_info(ctx.message.author.id)
-                    await requesting_user.send(
-                        content="Hey, here's your readme config file!",
-                        file=File(raw_json, 'readme.json')
-                    )
-
-                    msg_confirmation = Embed(
-                        colour=0x009688,
-                        description=":airplane: **Flying in, check your DMs!**"
-                    )
-                    await ctx.message.delete()
-                    await ctx.send(embed=msg_confirmation)
+            msg_confirmation = Embed(
+                colour=0x009688,
+                description=":airplane: **Flying in, check your DMs!**"
+            )
+            await ctx.message.delete()
+            await ctx.send(embed=msg_confirmation)
 
 def setup(bot):
     bot.add_cog(ReadmeCommands(bot))

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -107,13 +107,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
                 content="Hey, here's your readme config file!",
                 file=File(raw_json, 'readme.json')
             )
-
-            msg_confirmation = Embed(
-                colour=0x009688,
-                description=":airplane: **Flying in, check your DMs!**"
-            )
-            await ctx.message.delete()
-            await ctx.send(embed=msg_confirmation)
+            await ctx.send(":airplane: **Flying in, check your DMs!**")
 
 def setup(bot):
     bot.add_cog(ReadmeCommands(bot))

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -4,7 +4,6 @@ from json import load
 
 import discord
 from discord.ext import commands
-from aiohttp import ClientSession
 
 from wwbot.config import conf
 from wwbot.permissions import chk_gamemaster

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -61,7 +61,7 @@ class ReadmeCommands(commands.Cog, name="Readme"):
                 if "text" in msg_embed:
                     current_embed.description = msg_embed["text"]
                 if "color" in msg_embed:
-                    current_embed.colour = discord.Colour(int(msg_embed["color"], 16))
+                    current_embed.colour = discord.Colour(msg_embed["color"])
 
                 # Parse the fields, if there are any.
                 if "fields" in msg_embed:

--- a/wwbot/readme_cmds.py
+++ b/wwbot/readme_cmds.py
@@ -128,14 +128,14 @@ class ReadmeCommands(commands.cog, name="Readme"):
             # Pull the readme JSON constant files and slide it into the user's DMs.
             elif operand in README_RECV_ALIASES:
                 # Get the human-readble readme data.
-                with open("cdbot/data/readme_raw.json", "rb") as readme_json:
+                with open("readme.json", "rb") as readme_json:
                     raw_json = readme_json.read()
 
                     # Slide it to the user's DMs.
                     requesting_user = await self.bot.get_user_info(ctx.message.author.id)
                     await requesting_user.send(
                         content="Hey, here's your readme config file!",
-                        file=File(raw_json, 'readme_raw.json')
+                        file=File(raw_json, 'readme.json')
                     )
 
                     msg_confirmation = Embed(


### PR DESCRIPTION
Essentially this system allows hot-plugging READMEs using a JSON config file. There is heavy validation on the command, and only Game Master role members will be able to use the command since it's a core server component.

This PR introduces the `:readme` command, which has two main functions.

`:readme pull` will DM the requesting Game Master role member a copy of the readme JSON file, which they can edit at will. get, fetch, and others work too, please check the code to view all aliases.

`:readme push <channel id> <interval in seconds, max 15 minutes>` will create the readme messages. If the user uploads a JSON file with the command, it will attempt to use that to create the messages, otherwise, if a JSON is not uploaded along with the command, it will use the default config as is on our server. Since a readme needs to be well spaced out, I've included the interval argument, which if optionally supplied will asynchronously wait before sending the next message for a clean message channel. Again there are many aliases and push isn't the only keyword.

The JSON syntax isn't too dissimilar to the way discord embed visualiser works, and it can be used to create messages featuring text, embeds with fields and descriptions or a combination of the lot. One look through `~/readme.json` should make it really obvious regarding the JSON syntax, but if you're not sure, you can ask me or use the online JSON editor to visualise the existing default JSON file.

Regards